### PR TITLE
(SIMP-1170) Duplicate resource restart-systemd

### DIFF
--- a/build/pupmod-named.spec
+++ b/build/pupmod-named.spec
@@ -1,6 +1,6 @@
 Summary: Named/Bind Puppet Module
 Name: pupmod-named
-Version: 4.3.0
+Version: 4.3.1
 Release: 0
 License: Apache License, Version 2.0
 Group: Applications/System
@@ -61,6 +61,10 @@ fi
 # Post uninstall stuff
 
 %changelog
+* Wed Jul 06 2016 Nick Miller <nick.miller@onyxpoint.com> - 4.3.1-0
+- Changed the Exec['restart-systemd'] to Exec['systemctl-daemon-reload']
+  to avoid a conflict with puppetlabs-postgresql
+
 * Fri Apr 15 2016 Nick Markowski <nmarkowski@keywcorp.com> - 4.3.0-0
 - Created work-around for https://bugzilla.redhat.com/show_bug.cgi?id=1278082
 - Users can modify the chroot path in named-chroot.service

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -51,7 +51,7 @@ class named::service (
       notify  => Service[$svcname]
     }
 
-    exec { 'restart-systemd':
+    exec { 'systemctl-daemon-reload':
       command     => 'systemctl daemon-reload',
       refreshonly => true,
       path        => '/bin:/usr/bin:/usr/local/bin',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-named",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "author":  "simp",
   "summary": "manages either a chrooted named process or a caching nameserver",
   "license": "Apache-2.0",


### PR DESCRIPTION
This module contained a resource which had a conflicting name with an
externally maintained module (puppetlabs-postgresql). The name was
changed and is now more appropriate for what it represents.

SIMP-1170 #close