### PR TITLE
(SIMP-1450) Updated to use deconflicted 'simpcat'

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,6 @@
+* Fri Sep 30 2016 Trevor Vaughan <tvaughan@onyxpoint.com> - 5.0.0-0
+- Updated to use the deconflicted 'simpcat'
+
 * Wed Jul 06 2016 Nick Miller <nick.miller@onyxpoint.com> - 4.3.1-0
 - Changed the Exec['restart-systemd'] to Exec['systemctl-daemon-reload']
   to avoid a conflict with puppetlabs-postgresql

--- a/build/rpm_metadata/requires
+++ b/build/rpm_metadata/requires
@@ -1,5 +1,5 @@
 Requires: pupmod-simp-compliance_markup
 Requires: pupmod-simp-iptables >= 4.1.0-3
 Requires: pupmod-simp-rsync >= 4.0.0-14
-Requires: pupmod-simp-simpcat >= 4.0.0-0
+Requires: pupmod-simp-simpcat >= 6.0.0-0
 Obsoletes: pupmod-named-test >= 0.0.1

--- a/manifests/caching.pp
+++ b/manifests/caching.pp
@@ -34,16 +34,16 @@ class named::caching(
     chroot_path => $_chroot_path
   }
 
-  concat_build { 'named_caching':
+  simpcat_build { 'named_caching':
     order  => ['header', '*.forward', 'footer'],
     target => "${_chroot_path}/etc/named_caching.forwarders"
   }
 
-  concat_fragment { 'named_caching+header':
+  simpcat_fragment { 'named_caching+header':
     content => 'forwarders {'
   }
 
-  concat_fragment { 'named_caching+footer':
+  simpcat_fragment { 'named_caching+footer':
     content => '};'
   }
 
@@ -140,7 +140,7 @@ class named::caching(
     group     => 'named',
     mode      => '0640',
     notify    => Class['named::service'],
-    subscribe => Concat_build['named_caching'],
+    subscribe => Simpcat_build['named_caching'],
     audit     => content
   }
 

--- a/manifests/caching/forwarders.pp
+++ b/manifests/caching/forwarders.pp
@@ -21,7 +21,7 @@ define named::caching::forwarders {
 
   $l_name = inline_template('<%= @name.delete(";").split.join("_") %>')
 
-  concat_fragment { "named_caching+${l_name}.forward":
+  simpcat_fragment { "named_caching+${l_name}.forward":
     content =>
       inline_template('<%= (@name.delete(";").split - ["127.0.0.1", "::1"]).join(";\n") + ";" %>')
   }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name":    "simp-named",
-  "version": "4.3.1",
+  "version": "5.0.0",
   "author":  "simp",
   "summary": "manages either a chrooted named process or a caching nameserver",
   "license": "Apache-2.0",
@@ -19,7 +19,7 @@
     },
     {
       "name": "simp/simpcat",
-      "version_requirement": ">= 4.0.0"
+      "version_requirement": ">= 6.0.0"
     },
     {
       "name": "simp/simplib",


### PR DESCRIPTION
Change the resource references to be 'simpcat' instead of 'concat' due
to the breaking change in 'simpcat'.

SIMP-1450 #comment Updated to use deconflicted 'simpcat'
SIMP-843 #comment Deconflicted 'named'
