### PR TITLE
(SIMP-4923) Update rsync::server references

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Fri Jan 11 2019 Adam Yohrling <adam.yohrling@onyxpoint.com> - 6.1.1-0
+- Remove references to `rsync::server::global`
+- Update version requirement for pupmod-simp-rsync
+
 * Thu Nov 01 2018 Jeanne Greulich <jeanne,greulich@onyxpoint.com> - 6.1.0-0
 - Static asset updates for puppet 5
 - Update badges and contribution guide URL in README.md

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@
 #
 #   * Ensure that the rsync space is being served out properly from the rsync
 #     server (probably your puppet master)
-#       include 'rsync::server::global'
+#       include 'rsync::server'
 #       # The word 'default' here is the equivalent of the
 #       # named::bind_dns_rsync variable above.
 #       rsync::server::section { "bind_dns_default_${environment}":

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-named",
-  "version": "6.1.0",
+  "version": "6.1.1",
   "author": "SIMP Team",
   "summary": "manages either a chrooted named process or a caching nameserver",
   "license": "Apache-2.0",
@@ -20,7 +20,7 @@
     },
     {
       "name": "simp/rsync",
-      "version_requirement": ">= 6.0.0 < 7.0.0"
+      "version_requirement": ">= 6.1.1 < 7.0.0"
     },
     {
       "name": "simp/simpcat",


### PR DESCRIPTION
This change updates the README to reflect updated pupmod-simp-rsync 
changes and change the version requirement of the module.

SIMP-4923 #comment updated refs in pupmod-simp-named

The should not be merged until https://github.com/simp/pupmod-simp-rsync/pull/51 is merged