### PR TITLE
(SIMP-6117) Use namespaced simplib::validate_net_list

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+* Tue Mar 19 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.2-0
+- Use simplib::validate_net_list in lieu of deprecated Puppet 3
+  validate_net_list
+
 * Thu Mar 07 2019 Liz Nemsick <lnemsick.simp@gmail.com> - 6.1.1-0
 - Update the upper bound of stdlib to < 6.0.0
 - Update a URL in the README.md

--- a/manifests/chroot.pp
+++ b/manifests/chroot.pp
@@ -31,7 +31,7 @@ class named::chroot (
 
   $_rsync_user = "bind_dns_${::named::bind_dns_rsync}_rsync_${::environment}_${facts['os']['name']}_${facts['os']['release']['major']}"
 
-  validate_net_list($rsync_server)
+  simplib::validate_net_list($rsync_server)
 
   file { $nchroot:
     ensure => 'directory',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,7 +65,7 @@ class named (
 
   simplib::assert_metadata( $module_name )
 
-  validate_net_list($rsync_server)
+  simplib::validate_net_list($rsync_server)
 
   if ( str2bool($::selinux_enforced)) {
     include 'named::non_chroot'

--- a/manifests/non_chroot.pp
+++ b/manifests/non_chroot.pp
@@ -26,7 +26,7 @@ class named::non_chroot (
     fail( 'named::non_chroot must be used with selinux!')
   }
 
-  validate_net_list($rsync_server)
+  simplib::validate_net_list($rsync_server)
 
   file { '/etc/named.conf':
     ensure  => 'file',

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-named",
-  "version": "6.1.1",
+  "version": "6.1.2",
   "author": "SIMP Team",
   "summary": "manages either a chrooted named process or a caching nameserver",
   "license": "Apache-2.0",


### PR DESCRIPTION
Use simplib::validate_net_list in lieu of deprecated Puppet 3
validate_net_list

SIMP-6117 #comment pupmod-simp-named