### PR TITLE
Support for Puppet 8 and stdlib 9

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,11 @@
+* Tue Aug 29 2023 Steven Pritchard <steve@sicura.us> - 6.6.0
+- Support for Puppet 8 and stdlib 9
+- Drop use of Stdlib::Compat::Integer type
+- Drop use of deprecated top-level facts
+- Update gem dependencies
+- Drop support for Puppet 6
+- Drop use of explicit top-scoping
+
 * Mon Jul 10 2023 Chris Tessmer <chris.tessmer@onyxpoint.com> - 6.5.0
 - Add RockyLinux 8 support
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ ENV['PDK_DISABLE_ANALYTICS'] ||= 'true'
 gem_sources.each { |gem_source| source gem_source }
 
 group :test do
-  puppet_version = ENV['PUPPET_VERSION'] || '~> 7'
+  puppet_version = ENV['PUPPET_VERSION'] || '~> 8'
   major_puppet_version = puppet_version.scan(/(\d+)(?:\.|\Z)/).flatten.first.to_i
   gem 'rake'
   gem 'puppet', puppet_version
@@ -22,9 +22,9 @@ group :test do
   gem 'metadata-json-lint'
   gem 'puppet-strings'
   gem 'puppet-lint-trailing_comma-check', :require => false
-  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.1'
-  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.12.1', '< 6']
-  gem( 'pdk', ENV['PDK_VERSION'] || '~> 2.0', :require => false) if major_puppet_version > 5
+  gem 'simp-rspec-puppet-facts', ENV['SIMP_RSPEC_PUPPET_FACTS_VERSION'] || '~> 3.7'
+  gem 'simp-rake-helpers', ENV['SIMP_RAKE_HELPERS_VERSION'] || ['>= 5.21.0', '< 6']
+  gem( 'pdk', ENV['PDK_VERSION'] || ['>= 2.0', '< 4.0'], :require => false) if major_puppet_version > 5
   gem 'pathspec', '~> 0.2' if Gem::Requirement.create('< 2.6').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
 end
 
@@ -37,7 +37,7 @@ end
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.28.0', '< 2']
+  gem 'simp-beaker-helpers', ENV['SIMP_BEAKER_HELPERS_VERSION'] || ['>= 1.32.1', '< 2']
   gem 'bcrypt_pbkdf'
 end
 

--- a/hiera.yaml
+++ b/hiera.yaml
@@ -5,9 +5,9 @@ defaults:
   data_hash: yaml_data
 hierarchy:
   - name: "OS + Release"
-    path: "os/%{facts.operatingsystem}-%{facts.operatingsystemmajrelease}.yaml"
+    path: "os/%{facts.os.name}-%{facts.os.release.major}.yaml"
   - name: "OS"
-    path: "os/%{facts.operatingsystem}.yaml"
+    path: "os/%{facts.os.name}.yaml"
   - name: "Kernel"
     path: "os/%{facts.kernel}.yaml"
   - name: "Common"

--- a/manifests/chroot.pp
+++ b/manifests/chroot.pp
@@ -23,17 +23,20 @@
 # @author https://github.com/simp/pupmod-simp-named/graphs/contributors
 #
 class named::chroot (
-  Stdlib::Absolutepath    $nchroot        = $::named::chroot_path,
-  String                  $bind_dns_rsync = $::named::bind_dns_rsync,
-  String                  $rsync_source   = "bind_dns_${::named::bind_dns_rsync}_${environment}_${facts['os']['name']}_${facts['os']['release']['major']}/named",
-  String                  $rsync_server   = $::named::rsync_server,
-  Stdlib::Compat::Integer $rsync_timeout  = $::named::rsync_timeout
+  Stdlib::Absolutepath $nchroot        = $named::chroot_path,
+  String               $bind_dns_rsync = $named::bind_dns_rsync,
+  String               $rsync_source   = "bind_dns_${named::bind_dns_rsync}_${environment}_${facts['os']['name']}_${facts['os']['release']['major']}/named",
+  String               $rsync_server   = $named::rsync_server,
+  Variant[
+    Integer[0],
+    Pattern[/\A\d+\z/]
+  ]                    $rsync_timeout  = $named::rsync_timeout,
 ) {
   assert_private()
 
-  include '::rsync'
+  include 'rsync'
 
-  $_rsync_user = "bind_dns_${::named::bind_dns_rsync}_rsync_${server_facts['environment']}_${facts['os']['name']}_${facts['os']['release']['major']}"
+  $_rsync_user = "bind_dns_${named::bind_dns_rsync}_rsync_${server_facts['environment']}_${facts['os']['name']}_${facts['os']['release']['major']}"
 
   simplib::validate_net_list($rsync_server)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,15 +67,17 @@
 # @author https://github.com/simp/pupmod-simp-named/graphs/contributors
 #
 class named (
-  Stdlib::Absolutepath    $chroot_path,
-  Boolean                 $chroot                          = !pick($facts['os']['selinux']['enforced'], false),
-  String                  $bind_dns_rsync                  = 'default',
-  Boolean                 $firewall                        = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
-  String                  $rsync_server                    = simplib::lookup('simp_options::rsync::server', { 'default_value' => '127.0.0.1' }),
-  Stdlib::Compat::Integer $rsync_timeout                   = simplib::lookup('simp_options::rsync::timeout', { 'default_value' => '2' }),
-  Boolean                 $sebool_named_write_master_zones = false
+  Stdlib::Absolutepath $chroot_path,
+  Boolean              $chroot                          = !pick($facts['os']['selinux']['enforced'], false),
+  String               $bind_dns_rsync                  = 'default',
+  Boolean              $firewall                        = simplib::lookup('simp_options::firewall', { 'default_value' => false }),
+  String               $rsync_server                    = simplib::lookup('simp_options::rsync::server', { 'default_value' => '127.0.0.1' }),
+  Variant[
+    Integer[0],
+    Pattern[/\A\d+\z/]
+  ]                    $rsync_timeout                   = simplib::lookup('simp_options::rsync::timeout', { 'default_value' => '2' }),
+  Boolean              $sebool_named_write_master_zones = false,
 ) {
-
   if defined(Class['named::caching']) {
     fail('You cannot include both ::named and ::named::caching')
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -14,9 +14,9 @@
 #   The path to the chroot jail
 class named::install (
   Boolean              $chroot      = true,
-  Stdlib::Absolutepath $chroot_path = $::named::chroot_path,
+  Stdlib::Absolutepath $chroot_path = $named::chroot_path,
   String               $ensure      = simplib::lookup('simp_options::package_ensure', { 'default_value' => 'installed' }),
-){
+) {
   assert_private()
 
   package { 'bind': ensure => $ensure }

--- a/manifests/non_chroot.pp
+++ b/manifests/non_chroot.pp
@@ -21,16 +21,19 @@
 # @author https://github.com/simp/pupmod-simp-named/graphs/contributors
 #
 class named::non_chroot (
-  String                  $bind_dns_rsync = $::named::bind_dns_rsync,
-  String                  $rsync_source   = "bind_dns_${::named::bind_dns_rsync}_${environment}_${facts['os']['name']}_${facts['os']['release']['major']}/named",
-  String                  $rsync_server   = $::named::rsync_server,
-  Stdlib::Compat::Integer $rsync_timeout  = $::named::rsync_timeout
-){
+  String               $bind_dns_rsync = $named::bind_dns_rsync,
+  String               $rsync_source   = "bind_dns_${named::bind_dns_rsync}_${environment}_${facts['os']['name']}_${facts['os']['release']['major']}/named",
+  String               $rsync_server   = $named::rsync_server,
+  Variant[
+    Integer[0],
+    Pattern[/\A\d+\z/]
+  ]                    $rsync_timeout  = $named::rsync_timeout,
+) {
   assert_private()
 
-  include '::rsync'
+  include 'rsync'
 
-  $_rsync_user = "bind_dns_${::named::bind_dns_rsync}_rsync_${server_facts['environment']}_${facts['os']['name']}_${facts['os']['release']['major']}"
+  $_rsync_user = "bind_dns_${named::bind_dns_rsync}_rsync_${server_facts['environment']}_${facts['os']['name']}_${facts['os']['release']['major']}"
 
   simplib::validate_net_list($rsync_server)
 

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -11,7 +11,7 @@
 #
 class named::service (
   Boolean              $chroot      = true,
-  Stdlib::Absolutepath $chroot_path = $::named::chroot_path
+  Stdlib::Absolutepath $chroot_path = $named::chroot_path,
 ) {
   assert_private()
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "simp-named",
-  "version": "6.5.0",
+  "version": "6.6.0",
   "author": "SIMP Team",
   "summary": "manages either a chrooted named process or a caching nameserver",
   "license": "Apache-2.0",
@@ -28,11 +28,11 @@
     },
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 6.4.0 < 8.0.0"
+      "version_requirement": ">= 6.4.0 < 10.0.0"
     },
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 8.0.0 < 9.0.0"
+      "version_requirement": ">= 8.0.0 < 10.0.0"
     }
   ],
   "operatingsystem_support": [
@@ -67,7 +67,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 6.22.1 < 8.0.0"
+      "version_requirement": ">= 7.0.0 < 9.0.0"
     }
   ]
 }

--- a/spec/acceptance/nodesets/default.yml
+++ b/spec/acceptance/nodesets/default.yml
@@ -21,4 +21,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet8') %>"

--- a/spec/acceptance/nodesets/oel.yml
+++ b/spec/acceptance/nodesets/oel.yml
@@ -21,4 +21,4 @@ HOSTS:
 CONFIG:
   log_level: verbose
   type: aio
-  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet7') %>"
+  puppet_collection: "<%= ENV.fetch('BEAKER_PUPPET_COLLECTION', 'puppet8') %>"


### PR DESCRIPTION
- Drop use of Stdlib::Compat::Integer type
- Drop use of deprecated top-level facts
- Update gem dependencies
- Drop support for Puppet 6
- Drop use of explicit top-scoping